### PR TITLE
refactoring read command 

### DIFF
--- a/TestShell/ReadCommand.cpp
+++ b/TestShell/ReadCommand.cpp
@@ -1,65 +1,10 @@
 ﻿
 #include "ReadCommand.h"
-#include <iostream>
-#include <sstream>
-#include <vector>
-#include <fstream>
-#include <cstdlib>
 
-// 문자열 분할 함수
-std::vector<std::string> split(const std::string& line) {
-    std::istringstream iss(line);
-    std::vector<std::string> tokens;
-    std::string token;
-    while (iss >> token) tokens.push_back(token);
-    return tokens;
-}
-
-// 실제 실행 함수
-std::string ReadCommand::executeCommand(const std::string& input) {
-    auto tokens = split(input);
-    if (tokens.empty()) return "";
-
-    const std::string& cmd = tokens[0];
-
-    if (cmd == "read" && tokens.size() == 2) {
-        int lba;
-        try {
-            lba = std::stoi(tokens[1]);
-        }
-        catch (...) {
-            std::ofstream fout("ssd_output.txt");
-            fout << "ERROR";
-            fout.close();
-            std::cerr << "ERROR" << std::endl;
-            return "ERROR";
-        }
-
-        if (lba < 0 || lba >= 100) {
-            std::ofstream fout("ssd_output.txt");
-            fout << "ERROR";
-            fout.close();
-            std::cerr << "ERROR" << std::endl;
-            return "ERROR";
-        }
-
-        std::string command = "ssd R " + std::to_string(lba);
-        callSystem(command);
-
-        std::string result = readOutput();
-        std::cout << result << std::endl;
-        return result;
-    }
-
-    return "INVALID COMMAND";
-}
-
-// 기본 system 호출
 int ReadCommand::callSystem(const std::string& cmd) {
     return system(cmd.c_str());
 }
 
-// 기본 파일 읽기
 std::string ReadCommand::readOutput() {
     std::ifstream fin("ssd_output.txt");
     std::string line;
@@ -67,14 +12,12 @@ std::string ReadCommand::readOutput() {
     return line;
 }
 
-// 인터랙티브 입력 함수
-void ReadCommand::run() {
-    std::string input;
-    while (true) {
-        std::cout << "SSD> ";
-        std::getline(std::cin, input);
-        std::string result = executeCommand(input);
-        if (result == "EXIT") break;
-        std::cout << result << std::endl;
-    }
+bool ReadCommand::Execute(const std::string& cmd, std::vector<std::string>& args) {
+    int lba = std::stoi(args[1]);
+    std::string command = "ssd R " + std::to_string(lba);
+    callSystem(command);
+
+    std::string result = readOutput();
+    std::cout << result << std::endl;
+    return true;
 }

--- a/TestShell/ReadCommand.cpp
+++ b/TestShell/ReadCommand.cpp
@@ -1,0 +1,80 @@
+﻿
+#include "ReadCommand.h"
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <fstream>
+#include <cstdlib>
+
+// 문자열 분할 함수
+std::vector<std::string> split(const std::string& line) {
+    std::istringstream iss(line);
+    std::vector<std::string> tokens;
+    std::string token;
+    while (iss >> token) tokens.push_back(token);
+    return tokens;
+}
+
+// 실제 실행 함수
+std::string ReadCommand::executeCommand(const std::string& input) {
+    auto tokens = split(input);
+    if (tokens.empty()) return "";
+
+    const std::string& cmd = tokens[0];
+
+    if (cmd == "read" && tokens.size() == 2) {
+        int lba;
+        try {
+            lba = std::stoi(tokens[1]);
+        }
+        catch (...) {
+            std::ofstream fout("ssd_output.txt");
+            fout << "ERROR";
+            fout.close();
+            std::cerr << "ERROR" << std::endl;
+            return "ERROR";
+        }
+
+        if (lba < 0 || lba >= 100) {
+            std::ofstream fout("ssd_output.txt");
+            fout << "ERROR";
+            fout.close();
+            std::cerr << "ERROR" << std::endl;
+            return "ERROR";
+        }
+
+        std::string command = "ssd R " + std::to_string(lba);
+        callSystem(command);
+
+        std::string result = readOutput();
+        std::cout << result << std::endl;
+        return result;
+    }
+
+    return "INVALID COMMAND";
+}
+
+// 기본 system 호출
+int ReadCommand::callSystem(const std::string& cmd) {
+    return system(cmd.c_str());
+}
+
+// 기본 파일 읽기
+std::string ReadCommand::readOutput() {
+    std::ifstream fin("ssd_output.txt");
+    std::string line;
+    std::getline(fin, line);
+    return line;
+}
+
+// 인터랙티브 입력 함수
+void ReadCommand::run() {
+    std::string input;
+    while (true) {
+        std::cout << "SSD> ";
+        std::getline(std::cin, input);
+        std::string result = executeCommand(input);
+        if (result == "EXIT") break;
+        std::cout << result << std::endl;
+    }
+}

--- a/TestShell/ReadCommand.h
+++ b/TestShell/ReadCommand.h
@@ -1,13 +1,37 @@
 
 #pragma once
+#include "ICommand.h"
 #include <string>
 #include <vector>
+#include <iostream>
+#include <fstream>
 
-class ReadCommand {
+class ReadCommand : public ICommand {
 public:
     virtual ~ReadCommand() = default;
-    void run();
-    std::string executeCommand(const std::string& input);
+
+    const std::string& getCommandString() override {
+        static std::string cmd = "read";
+        return cmd;
+    }
+
+    const std::string& getUsage() override {
+        static std::string usage = "read <LBA>";
+        return usage;
+    }
+
+    bool isValidArguments(const std::string& cmd, std::vector<std::string>& args) override {
+        if (args.size() != 2) return false;
+        try {
+            int lba = std::stoi(args[1]);
+            return lba >= 0 && lba < 100;
+        }
+        catch (...) {
+            return false;
+        }
+    }
+
+    bool Execute(const std::string& cmd, std::vector<std::string>& args) override;
 
 protected:
     virtual int callSystem(const std::string& cmd);


### PR DESCRIPTION
ReadCommand 리팩토링: ICommand 기반 구조로 전환
- 기존 ReadCommand 클래스에 있던 실행 로직을 ICommand 인터페이스에 맞게 정리
- callSystem(), readOutput()은 virtual 함수로 분리하여 테스트 용이성 확보
- TestShell 구조에 통합 가능도록 명령어 클래스로 변경