### PR TITLE
[refactor] write commands 객체화

### DIFF
--- a/TestShell/TestShell.cpp
+++ b/TestShell/TestShell.cpp
@@ -6,6 +6,8 @@
 #include <vector>
 #include "TestShell.h"
 #include "ICommand.h"
+#include "ReadCommand.h"
+#include "WriteCommand.h"
 #include "Script1.h"
 #include "Script2.h"
 
@@ -24,9 +26,13 @@ TestShell::TestShell()
 {
 	exitCommand = make_shared<ExitCommand>();
 	helpCommand = make_shared<HelpCommand>();
+	readCommand = make_shared<ReadCommand>();
+	writeCommand = make_shared<WriteCommand>();
 
 	addCommand(exitCommand);
 	addCommand(helpCommand);
+	addCommand(readCommand);
+	addCommand(writeCommand);
 }
 void TestShell::run()
 {
@@ -101,4 +107,5 @@ void TestShell::addCommand(shared_ptr<ICommand> newCommand)
 {
 	commandList.emplace_back(newCommand);
 	helpCommand->addHelp(newCommand->getUsage());
+
 }

--- a/TestShell/TestShell.h
+++ b/TestShell/TestShell.h
@@ -31,5 +31,7 @@ private:
 	vector<shared_ptr<ICommand>> commandList;
 	shared_ptr<ExitCommand> exitCommand;
 	shared_ptr<HelpCommand> helpCommand;
+	shared_ptr<ReadCommand> readCommand;
+	shared_ptr<WriteCommand> writeCommand;
 };
 

--- a/TestShell/WriteCommand.cpp
+++ b/TestShell/WriteCommand.cpp
@@ -1,0 +1,41 @@
+#include "WriteCommand.h"
+#include <iostream>
+#include <sstream>
+#include <regex>
+#include <cstdlib>
+
+const std::string& WriteCommand::getCommandString() {
+    return command;
+}
+
+const std::string& WriteCommand::getUsage() {
+    return usage;
+}
+
+bool WriteCommand::isValidArguments(const std::string& cmd, std::vector<std::string>& args) {
+    if (args.size() != 2) return false;
+
+    try {
+        int lba = std::stoi(args[0]);
+        if (lba < 0 || lba >= 100) return false;
+
+        std::regex patternRegex("0x[0-9A-Fa-f]{8}");
+        return std::regex_match(args[1], patternRegex);
+    }
+    catch (...) {
+        return false;
+    }
+}
+
+bool WriteCommand::Execute(const std::string& cmd, std::vector<std::string>& args) {
+    std::ostringstream oss;
+    oss << "ssd.exe write " << args[0] << " " << args[1];
+
+    int result = system(oss.str().c_str());
+    if (result != 0) {
+        std::cout << "[ERROR] Failed to execute: " << oss.str() << std::endl;
+        return false;
+    }
+
+    return true;
+}

--- a/TestShell/WriteCommand.h
+++ b/TestShell/WriteCommand.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "ICommand.h"
+#include <string>
+#include <vector>
+
+class WriteCommand : public ICommand {
+public:
+    const std::string& getCommandString() override;
+    const std::string& getUsage() override;
+    bool isValidArguments(const std::string& cmd, std::vector<std::string>& args) override;
+    bool Execute(const std::string& cmd, std::vector<std::string>& args) override;
+
+private:
+    const std::string command = "write";
+    const std::string usage = "write <LBA> <PATTERN> : 해당 LBA에 패턴을 저장합니다.";
+};


### PR DESCRIPTION
1. 함수로 처리되던 Write 명령 객체화
- 명령어 등록이 TestShell에서 일관되게 관리됨
2. TestShell에서 ReadCommand, WriteCommand 등록