### PR TITLE
WtoW ignore added & flush not excute when ignored

### DIFF
--- a/SSD/src/CommandBuffer.cpp
+++ b/SSD/src/CommandBuffer.cpp
@@ -23,14 +23,16 @@ void CommandBuffer::Init() {
 void CommandBuffer::AddCommand(const std::string& command) {
   if (!IsWriteOrEraseCommand(command)) return;
 
-  if (GetValidBufferCount() >= MAX_BUFFER_SIZE) {
-    ClearBuffer();
-  }
-
   if (command[0] == 'W') {
     processWrite(command);
   } else if (command[0] == 'E') {
     processErase(command);
+  }
+
+  SaveBuffer();
+
+  if (GetValidBufferCount() >= MAX_BUFFER_SIZE) {
+    ClearBuffer();
   }
 
   commands.push_back(command);
@@ -38,7 +40,26 @@ void CommandBuffer::AddCommand(const std::string& command) {
   SaveBuffer();
 }
 
-void CommandBuffer::processWrite(const std::string& command) {}
+void CommandBuffer::processWrite(const std::string& command) {
+  std::istringstream iss(command);
+  std::string type;
+  int lba;
+  std::string value;
+
+  iss >> type >> lba >> value;
+
+  commands.erase(std::remove_if(commands.begin(), commands.end(),
+                                [lba](const std::string& cmd) {
+                                  std::istringstream iss(cmd);
+                                  std::string t;
+                                  int l;
+                                  iss >> t >> l;
+                                  return t == "W" && l == lba;
+                                }),
+                 commands.end());
+
+  
+}
 
 void CommandBuffer::processErase(const std::string& command) {}
 

--- a/SSD/test/CommandBufferTest.cpp
+++ b/SSD/test/CommandBufferTest.cpp
@@ -134,6 +134,7 @@ TEST_F(CommandBufferTest, Write_Buffer) {
   ssdInterface->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
   ssdInterface->Read(VALID_LBA_BEGIN);
   EXPECT_EQ(VALID_VALUE_1, ssdInterface->GetResult());
+  ssdInterface->ClearCommandBuffer();
 }
 
 TEST_F(CommandBufferTest, Erase_Buffer) {
@@ -141,6 +142,7 @@ TEST_F(CommandBufferTest, Erase_Buffer) {
   ssdInterface->Erase(VALID_LBA_BEGIN, "1");
   ssdInterface->Read(VALID_LBA_BEGIN);
   EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
+  ssdInterface->ClearCommandBuffer();
 }
 
 TEST_F(CommandBufferTest, Implicit_Flush_Buffer) {
@@ -154,6 +156,7 @@ TEST_F(CommandBufferTest, Implicit_Flush_Buffer) {
     ssdInterface->Read(lba);
     EXPECT_EQ(VALID_VALUE_1, ssdInterface->GetResult());
   }
+  ssdInterface->ClearCommandBuffer();
 }
 
 TEST_F(CommandBufferTest, WtoW_Ignore_Buffer) {
@@ -163,6 +166,18 @@ TEST_F(CommandBufferTest, WtoW_Ignore_Buffer) {
   EXPECT_EQ(1, buffer.GetValidBufferCount());
   ssdInterface->Read(VALID_LBA_BEGIN);
   EXPECT_EQ(VALID_VALUE_2, ssdInterface->GetResult());
+  buffer.DestroyBuffer();
+}
+
+TEST_F(CommandBufferTest, WtoW_Not_Flush_Buffer_with_ignored) {
+  CommandBuffer buffer(bufferDir);
+  buffer.AddCommand("W 0 0x12345678");
+  buffer.AddCommand("W 1 0x12345678");
+  buffer.AddCommand("W 2 0x12345678");
+  buffer.AddCommand("W 3 0x12345678");
+  buffer.AddCommand("W 4 0x12345678");
+  buffer.AddCommand("W 4 0x12345678");
+  EXPECT_EQ(5, buffer.GetValidBufferCount());
   buffer.DestroyBuffer();
 }
 
@@ -270,3 +285,12 @@ TEST_F(CommandBufferTest, EtoE_Merge_Multiple_Buffers_1) {
   EXPECT_EQ("E 0 7", commands[0]);
   buffer.DestroyBuffer();
 }
+
+TEST_F(CommandBufferTest, EtoW_Not_Ignore_Buffer) {
+  CommandBuffer buffer(bufferDir);
+  buffer.AddCommand("E 0 5");
+  buffer.AddCommand("W 2 0x12345678");
+  EXPECT_EQ(2, buffer.GetValidBufferCount());
+  buffer.DestroyBuffer();
+}
+


### PR DESCRIPTION
1. Write to Write ingore feature 구현했습니다.
2. 5개의 command가 add 된 후에 write command가 들어와서 ingore된다면 flush 안되고 5개가 유지되게끔했습니다.
3. Erase 범위 사이에 W가 들어와도 ignore 안되게 했습니다. 왜냐하면 command가 늘어나기때문입니다.
4. 그외에 command buffer 초기화를 추가했습니다.