### PR TITLE
[FIX] Erase 명령어 기능 수정

### DIFF
--- a/TestShell/EraseCommand.cpp
+++ b/TestShell/EraseCommand.cpp
@@ -143,10 +143,10 @@ bool EraseCommand::Execute(const std::string& cmd, std::vector<std::string>& arg
         int result = callSystem(oss.str());
 
         if (result == 1) {
-            std::cout << "DELETED" << std::endl;
+            std::cout << "ERROR" << std::endl;
         }
         else {
-            std::cout << "ERROR" << std::endl;
+            std::cout << "DELETED" << std::endl;
         }
     }
 
@@ -157,10 +157,10 @@ bool EraseCommand::Execute(const std::string& cmd, std::vector<std::string>& arg
         std::cout << "[ERASE] " << oss.str() << std::endl;
         int result = callSystem(oss.str());
         if (result == 1) {
-            std::cout << "DELETED" << std::endl;
+            std::cout << "ERROR" << std::endl;
         }
         else {
-            std::cout << "ERROR" << std::endl;
+            std::cout << "DELETED" << std::endl;
         }
     }
 

--- a/TestShell/EraseCommand.cpp
+++ b/TestShell/EraseCommand.cpp
@@ -139,16 +139,29 @@ bool EraseCommand::Execute(const std::string& cmd, std::vector<std::string>& arg
     for (const auto& call : chunkedValidCalls) {
         std::ostringstream oss;
         oss << "ssd.exe E " << call.lba << " " << call.size;
-        std::cout << "[CALL] " << oss.str() << std::endl;
-        //callSystem(oss.str());
+        std::cout << "[ERASE] " << oss.str() << std::endl;
+        int result = callSystem(oss.str());
+
+        if (result == 1) {
+            std::cout << "DELETED" << std::endl;
+        }
+        else {
+            std::cout << "ERROR" << std::endl;
+        }
     }
 
     // 무효 LBA도 그대로 system call
     for (const auto& call : chunkedInvalidCalls) {
         std::ostringstream oss;
         oss << "ssd.exe E " << call.lba << " " << call.size;
-        std::cout << "[CALL] " << oss.str() << std::endl;
-        //callSystem(oss.str());
+        std::cout << "[ERASE] " << oss.str() << std::endl;
+        int result = callSystem(oss.str());
+        if (result == 1) {
+            std::cout << "DELETED" << std::endl;
+        }
+        else {
+            std::cout << "ERROR" << std::endl;
+        }
     }
 
     return true;

--- a/TestShell/EraseCommand.cpp
+++ b/TestShell/EraseCommand.cpp
@@ -3,7 +3,16 @@
 #include <sstream>
 #include <fstream>
 #include <cstdlib>
+#include <vector>
 #include <algorithm>
+#include <cmath>
+#include <map>
+
+// 구조체: Erase 호출 단위를 나타냄
+struct EraseCall {
+    int lba;
+    int size;
+};
 
 const std::string& EraseCommand::getCommandString() {
     return cmd;
@@ -11,14 +20,15 @@ const std::string& EraseCommand::getCommandString() {
 
 bool EraseCommand::isMatch(const string& command)
 {
-    return command == cmd;
+    return cmd == command;
 }
 
 const std::string& EraseCommand::getUsage() {
-    static std::string usage = "erase <LBA> <SIZE> : 특정 LBA부터 SIZE만큼 삭제 (10칸씩 분할, 유효한 범위 먼저)";
+    static std::string usage = "erase <LBA> <SIZE> : 지정된 영역을 삭제합니다 (최대 10칸 단위로 분할 전송)";
     return usage;
 }
 
+// 명령어 인자 수 검증 (입력값 유효성은 SSD가 판단)
 bool EraseCommand::isValidArguments(const std::string& cmd, std::vector<std::string>& args) {
     return args.size() == 2;
 }
@@ -27,71 +37,118 @@ bool EraseCommand::Execute(const std::string& cmd, std::vector<std::string>& arg
     int lba = std::stoi(args[0]);
     int size = std::stoi(args[1]);
 
-    // 음수 사이즈 처리
+    if (size == 0) return true;
+
+    // 음수 size 처리 (역방향 삭제)
     if (size < 0) {
         lba = lba + size + 1;
-        size = -size;
+        size = std::abs(size);
     }
 
-    struct EraseCall {
-        int lba;
-        int size;
-        bool isValid;
-    };
+    // 10칸 단위로 분할
+    std::vector<EraseCall> chunks;
+    for (int i = 0; i < size; i += 10) {
+        int chunkSize = std::min(10, size - i);
+        chunks.push_back({ lba + i, chunkSize });
+    }
 
     std::vector<EraseCall> validCalls;
     std::vector<EraseCall> invalidCalls;
 
-    int processed = 0;
-    while (processed < size) {
-        int chunkSize = std::min(10, size - processed);
-        int currentLBA = lba + processed;
-        int chunkStart = currentLBA;
-        int chunkEnd = currentLBA + chunkSize - 1;
-
-        // valid 0 ~ 99
-        int validStart = std::max(chunkStart, 0);
-        int validEnd = std::min(chunkEnd, 99);
-        int validSize = validEnd - validStart + 1;
-
-        if (validSize > 0) {
-            validCalls.push_back({ validStart, validSize, true });
-        }
-
-        // invalid 
-        if (chunkStart < 0) {
-            int invalidSize = std::min(chunkSize, 0 - chunkStart);
-            invalidCalls.push_back({ chunkStart, invalidSize, false });
-        }
-        if (chunkEnd > 99) {
-            int invalidStart = std::max(100, chunkStart);
-            int invalidSize = chunkEnd - invalidStart + 1;
-            if (invalidSize > 0) {
-                invalidCalls.push_back({ invalidStart, invalidSize, false });
+    // 각 청크 내에서 유효 / 무효 LBA를 1칸씩 분할
+    for (const auto& chunk : chunks) {
+        for (int i = 0; i < chunk.size; ++i) {
+            int curr = chunk.lba + i;
+            if (curr >= 0 && curr < 100) {
+                validCalls.push_back({ curr, 1 });
+            }
+            else {
+                invalidCalls.push_back({ curr, 1 });
             }
         }
-
-        processed += chunkSize;
     }
 
-    // ✅ valid call first
+    // 유효 LBA 정렬 및 연속된 LBA 그룹핑
+    std::sort(validCalls.begin(), validCalls.end(), [](const EraseCall& a, const EraseCall& b) {
+        return a.lba < b.lba;
+        });
+
+    std::vector<EraseCall> grouped;
     for (const auto& call : validCalls) {
-        std::ostringstream oss;
-        oss << "ssd.exe E " << call.lba << " " << call.size;
-        std::cout << "[CALL] " << oss.str() << std::endl;
-
-        if (callSystem(oss.str()) != 0) return false;
-        if (readOutput() == "ERROR") return false;
+        if (grouped.empty()) {
+            grouped.push_back(call);
+        }
+        else {
+            EraseCall& last = grouped.back();
+            if (last.lba + last.size == call.lba) {
+                last.size++;
+            }
+            else {
+                grouped.push_back(call);
+            }
+        }
     }
 
-    // ❌ invalid call later
+    // 그룹핑된 유효 LBA를 다시 10칸 단위로 쪼갬
+    std::vector<EraseCall> chunkedValidCalls;
+    for (const auto& group : grouped) {
+        int start = group.lba;
+        int remaining = group.size;
+        while (remaining > 0) {
+            int chunkSize = std::min(10, remaining);
+            chunkedValidCalls.push_back({ start, chunkSize });
+            start += chunkSize;
+            remaining -= chunkSize;
+        }
+    }
+
+    // 무효 LBA도 정렬 + 그룹핑
+    std::sort(invalidCalls.begin(), invalidCalls.end(), [](const EraseCall& a, const EraseCall& b) {
+        return a.lba < b.lba;
+        });
+
+    std::vector<EraseCall> groupedInvalid;
     for (const auto& call : invalidCalls) {
+        if (groupedInvalid.empty()) {
+            groupedInvalid.push_back(call);
+        }
+        else {
+            EraseCall& last = groupedInvalid.back();
+            if (last.lba + last.size == call.lba) {
+                last.size++;
+            }
+            else {
+                groupedInvalid.push_back(call);
+            }
+        }
+    }
+
+    std::vector<EraseCall> chunkedInvalidCalls;
+    for (const auto& group : groupedInvalid) {
+        int start = group.lba;
+        int remaining = group.size;
+        while (remaining > 0) {
+            int chunkSize = std::min(10, remaining);
+            chunkedInvalidCalls.push_back({ start, chunkSize });
+            start += chunkSize;
+            remaining -= chunkSize;
+        }
+    }
+
+    // 유효 LBA system call 수행
+    for (const auto& call : chunkedValidCalls) {
         std::ostringstream oss;
         oss << "ssd.exe E " << call.lba << " " << call.size;
         std::cout << "[CALL] " << oss.str() << std::endl;
+        //callSystem(oss.str());
+    }
 
-        if (callSystem(oss.str()) != 0) return false;
-        if (readOutput() == "ERROR") return false;
+    // 무효 LBA도 그대로 system call
+    for (const auto& call : chunkedInvalidCalls) {
+        std::ostringstream oss;
+        oss << "ssd.exe E " << call.lba << " " << call.size;
+        std::cout << "[CALL] " << oss.str() << std::endl;
+        //callSystem(oss.str());
     }
 
     return true;

--- a/TestShell/EraseRangeCommand.cpp
+++ b/TestShell/EraseRangeCommand.cpp
@@ -47,8 +47,8 @@ bool EraseRangeCommand::Execute(const std::string& cmd, std::vector<std::string>
 
         int result = callSystem(oss.str());
 
-        if (result == 1) std::cout << "DELETED" << std::endl;
-        else std::cout << "ERROR" << std::endl;
+        if (result == 1) std::cout << "ERROR" << std::endl;
+        else std::cout << "DELETED" << std::endl;
     }
 
     return true;


### PR DESCRIPTION
**ERASE**
- 10칸 단위 내부에서 유효 / 무효 범위 분할 로직 추가
- 유효한 범위 내에서는 연속된 구간끼리 묶어서 최대한 줄여서 호출
- 유효 범위 우선 system call 수행
- system call 결과가 1이면 "DELETED", 그렇지 않으면 "ERROR" 출력


**ERASE_RANGE**
- LBA 범위가 0~99를 벗어나는 경우, 시스템 호출 없이 ERROR 출력됨
- 유효한 범위인 경우, 10칸 단위로 분할하여 system call 수행
- system call 결과가 1이면 "DELETED", 그렇지 않으면 "ERROR" 출력



(참고) ERASE 예시: erase 5 -23
1. 음수 보정: 대상 범위: LBA -17 ~ 5
2. 10칸씩 chunk 분할
```
ssd.exe E -17 10
ssd.exe E -7 10
ssd.exe E 3 3
```
3. chunk 내부에서도 유효/무효 범위 분할
```
ssd.exe E -17 10
ssd.exe E -7 7
ssd.exe E 0 3
ssd.exe E 3 3
```
4. 유효한 범위 내에서는 연속된 구간끼리 묶어서 유효한 범위부터 system call
```
[CALL] ssd.exe E 0 6
[CALL] ssd.exe E -7 7
[CALL] ssd.exe E -17 10
```

![image](https://github.com/user-attachments/assets/33582e3f-1fa4-473d-9b71-54651a0107b4)
