### PR TITLE
[REFACTOR] Factory pattern 적용

### DIFF
--- a/SSD/SSD.vcxproj
+++ b/SSD/SSD.vcxproj
@@ -245,11 +245,14 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\CommandBuffer.h" />
+    <ClInclude Include="src\RealSsdComponentFactory.h" />
     <ClInclude Include="src\Recoder.h" />
+    <ClInclude Include="src\SsdComponentFactory.h" />
     <ClInclude Include="src\SsdType.h" />
     <ClInclude Include="src\Validator.h" />
     <ClInclude Include="src\NandStorage.h" />
     <ClInclude Include="src\SsdController.h" />
+    <ClInclude Include="test\TestSsdComponentFactory.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/SSD/SSD.vcxproj.filters
+++ b/SSD/SSD.vcxproj.filters
@@ -68,5 +68,14 @@
     <ClInclude Include="src\CommandBuffer.h">
       <Filter>헤더 파일</Filter>
     </ClInclude>
+    <ClInclude Include="src\SsdComponentFactory.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="src\RealSsdComponentFactory.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
+    <ClInclude Include="test\TestSsdComponentFactory.h">
+      <Filter>헤더 파일</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/SSD/src/RealSsdComponentFactory.h
+++ b/SSD/src/RealSsdComponentFactory.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "SsdComponentFactory.h"
+
+class RealSsdComponentFactory : public SsdComponentFactory {
+ public:
+  std::unique_ptr<NandStorage> createNandStorage() override {
+    return std::make_unique<NandStorage>();
+  }
+  std::unique_ptr<Recoder> createRecoder() override {
+    return std::make_unique<Recoder>();
+  }
+  std::unique_ptr<Validator> createValidator() override {
+    return std::make_unique<Validator>();
+  }
+};

--- a/SSD/src/SsdComponentFactory.h
+++ b/SSD/src/SsdComponentFactory.h
@@ -1,0 +1,9 @@
+#pragma once
+
+class SsdComponentFactory {
+ public:
+  virtual ~SsdComponentFactory() = default;
+  virtual std::unique_ptr<NandStorage> createNandStorage() = 0;
+  virtual std::unique_ptr<Recoder> createRecoder() = 0;
+  virtual std::unique_ptr<Validator> createValidator() = 0;
+};

--- a/SSD/src/SsdController.cpp
+++ b/SSD/src/SsdController.cpp
@@ -7,7 +7,7 @@
 
 void SsdController::Write(std::string lba, std::string dataPattern) {
   if (isValidLba(lba) == false || isValidData(dataPattern) == false) {
-    recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+    recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
     return;
   }
 
@@ -23,7 +23,7 @@ void SsdController::ClearCommandBuffer() { commandBuffer.ClearBuffer(); }
 
 void SsdController::Read(std::string lba) { 
   if (isValidLba(lba) == false) {
-    return recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+    return recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
   }
 
   std::string stringReadData = FAIL_BUFFER_READ_MESSAGE;
@@ -33,33 +33,33 @@ void SsdController::Read(std::string lba) {
 
   if (stringReadData == FAIL_BUFFER_READ_MESSAGE) {
     std::ifstream nandFile(NAND_FILE_NAME, std::ios::binary);
-    if (nandStorage.IsExistNand() == false) {
-      recoder.RecordZeroPatternToOutputFile();
+    if (nandStorage->IsExistNand() == false) {
+      recoder->RecordZeroPatternToOutputFile();
       return;
     }  
 
-    unsigned int readData = nandStorage.Read(lba);
+    unsigned int readData = nandStorage->Read(lba);
     stringReadData = unsignedIntToPrefixedHexString(readData);
   }
 
-  return recoder.RecordSuccessPatternToOutputFile(stringReadData);
+  return recoder->RecordSuccessPatternToOutputFile(stringReadData);
 }
 
 void SsdController::Erase(std::string lba, std::string scope) {
   if (isValidScope(scope) == false) {
-    return recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+    return recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
   }
 
-  if (validator.IsNumberWithinRange(lba, 0, MAX_LBA) == false) {
-    return recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+  if (validator->IsNumberWithinRange(lba, 0, MAX_LBA) == false) {
+    return recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
   }
 
   int numLba = stoi(lba);
   int numScope = stoi(scope);
   std::string endLba = std::to_string(numLba + numScope);
 
-  if (validator.IsNumberWithinRange(endLba, 0, MAX_LBA) == false) {
-    return recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+  if (validator->IsNumberWithinRange(endLba, 0, MAX_LBA) == false) {
+    return recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
   }
 
   if (numScope < 0) {
@@ -97,9 +97,9 @@ void SsdController::Flush() {
       issCommand >> lba >> scope;
       processEraseCommand(lba, scope);
     } else {
-      validator.SetErrorReason(" ### Buffer Is Brocken ### (commandType: " +
+      validator->SetErrorReason(" ### Buffer Is Brocken ### (commandType: " +
                                commandType);
-      return recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+      return recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
     }
   }
 
@@ -108,9 +108,9 @@ void SsdController::Flush() {
 
 void SsdController::processWriteCommand(const std::string& lba,
                          const std::string& dataPattern) {
-  if (nandStorage.Write(lba, dataPattern) == false) {
-    validator.SetErrorReason(" ### Write Fail (about File) ### ");
-    recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+  if (nandStorage->Write(lba, dataPattern) == false) {
+    validator->SetErrorReason(" ### Write Fail (about File) ### ");
+    recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
   }
 }
 
@@ -118,16 +118,16 @@ void SsdController::processEraseCommand(std::string lba, std::string scope) {
   int writeCount = std::stoi(scope);
   int lastLba = std::stoi(lba) + writeCount;
   if (lastLba > MAX_LBA) {
-    validator.SetErrorReason("### Last LBA is over Max LBA ###");
-    return recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+    validator->SetErrorReason("### Last LBA is over Max LBA ###");
+    return recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
   }
 
   for (int writeOffset = 0; writeOffset < writeCount; writeOffset++) {
     std::string currentLba = std::to_string(std::stoi(lba) + writeOffset);
 
-    if (nandStorage.Write(currentLba, ZERO_PATTERN) == false) {
-      validator.SetErrorReason(" ### Write Fail (about File) ### ");
-      recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+    if (nandStorage->Write(currentLba, ZERO_PATTERN) == false) {
+      validator->SetErrorReason(" ### Write Fail (about File) ### ");
+      recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
     }
   }
 }
@@ -140,18 +140,18 @@ std::string SsdController::unsignedIntToPrefixedHexString(unsigned int readData)
 }
 
 void SsdController::InvalidCommand(std::string errorMessage) {
-  validator.SetErrorReason(errorMessage);
-  recoder.RecordErrorPatternToOutputFile(validator.GetErrorReason());
+  validator->SetErrorReason(errorMessage);
+  recoder->RecordErrorPatternToOutputFile(validator->GetErrorReason());
 }
 
 bool SsdController::isValidLba(const std::string& lba) {
-  return validator.IsNumberWithinRange(lba, 0, MAX_LBA);
+  return validator->IsNumberWithinRange(lba, 0, MAX_LBA);
 }
 
 bool SsdController::isValidScope(const std::string& scope) {
-  return validator.IsNumberWithinRange(scope, 1, 10, true);
+  return validator->IsNumberWithinRange(scope, 1, 10, true);
 }
 
 bool SsdController::isValidData(const std::string& dataPattern) {
-  return validator.IsValidDataPattern(dataPattern);
+  return validator->IsValidDataPattern(dataPattern);
 }

--- a/SSD/src/SsdController.h
+++ b/SSD/src/SsdController.h
@@ -3,11 +3,17 @@
 #include <fstream>
 #include "NandStorage.h"
 #include "validator.h"
-#include "Recoder.h"
+#include "recoder.h"
 #include "CommandBuffer.h"
+#include "SsdComponentFactory.h"
 
 class SsdController {
  public:
+  SsdController(std::unique_ptr<SsdComponentFactory> factory)
+      : nandStorage(factory->createNandStorage()),
+        recoder(factory->createRecoder()),
+        validator(factory->createValidator()){};
+
   void Write(std::string lba, std::string dataPattern);
   void Read(std::string lba);
   void Erase(std::string lba, std::string scope);
@@ -16,14 +22,14 @@ class SsdController {
 
   void InvalidCommand(std::string errorMessage);
 
-  void ResetResult() { recoder.ResetResult(); };
+  void ResetResult() { recoder->ResetResult(); };
   void ClearCommandBuffer();
-  std::string GetResult() { return recoder.GetResult(); };
+  std::string GetResult() { return recoder->GetResult(); };
 
  private:
-  NandStorage nandStorage;
-  Validator validator;
-  Recoder recoder;
+  std::unique_ptr<NandStorage> nandStorage;
+  std::unique_ptr<Recoder> recoder;
+  std::unique_ptr<Validator> validator;
   CommandBuffer commandBuffer;
 
   void processWriteCommand(const std::string& lba,

--- a/SSD/src/main.cpp
+++ b/SSD/src/main.cpp
@@ -5,11 +5,14 @@
 
 #include "SsdType.h"
 #include "SsdController.h"
+#include "RealSsdComponentFactory.h"
 
 int main(int argc, char* argv[]) {
-  SsdController ssdInterface;
+  std::unique_ptr<SsdComponentFactory> realFactory =
+      std::make_unique<RealSsdComponentFactory>();
+  SsdController ssdControllerWithReal(std::move(realFactory));
 
-  ssdInterface.ResetResult();
+  ssdControllerWithReal.ResetResult();
 
   try {
     // 명령어 개수 검사
@@ -27,7 +30,7 @@ int main(int argc, char* argv[]) {
         throw std::invalid_argument("Insufficient read arguments.");
       }
 
-      ssdInterface.Read(lbaStr);
+      ssdControllerWithReal.Read(lbaStr);
     } else if (command == "W") {
       if (argc != 4) {
         throw std::invalid_argument("Insufficient write arguments.");
@@ -35,7 +38,7 @@ int main(int argc, char* argv[]) {
 
       std::string value = argv[3];
 
-      ssdInterface.Write(lbaStr, value);
+      ssdControllerWithReal.Write(lbaStr, value);
     } else if (command == "E") {
       if (argc != 4) {
         throw std::invalid_argument("Insufficient erase arguments.");
@@ -43,19 +46,19 @@ int main(int argc, char* argv[]) {
 
       std::string scope = argv[3];
 
-      ssdInterface.Erase(lbaStr, scope);
+      ssdControllerWithReal.Erase(lbaStr, scope);
     } else if (command == "F") {
       if (argc != 2) {
         throw std::invalid_argument("Insufficient flush arguments.");
       }
 
-      ssdInterface.Flush();
+      ssdControllerWithReal.Flush();
     } else {
       throw std::invalid_argument("Insufficient comment.");
     }
   } catch (const std::exception& errorMessage) {
-    ssdInterface.InvalidCommand(errorMessage.what());
+    ssdControllerWithReal.InvalidCommand(errorMessage.what());
   }
 
-  return (ssdInterface.GetResult() == ERROR_PATTERN);
+  return (ssdControllerWithReal.GetResult() == ERROR_PATTERN);
 }

--- a/SSD/test/TestSsdComponentFactory.h
+++ b/SSD/test/TestSsdComponentFactory.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "../src/SsdComponentFactory.h"
+
+class TestSsdComponentFactory : public SsdComponentFactory {
+ public:
+  std::unique_ptr<NandStorage> createNandStorage() override {
+    return std::make_unique<NandStorage>();
+  }
+  std::unique_ptr<Recoder> createRecoder() override {
+    return std::make_unique<Recoder>();
+  }
+  std::unique_ptr<Validator> createValidator() override {
+    return std::make_unique<Validator>();
+  }
+};

--- a/SSD/test/test_main.cpp
+++ b/SSD/test/test_main.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "../src/SsdType.h"
 #include "../src/SsdController.h"
+#include "TestSsdComponentFactory.h"
 
 #include <fstream>
 #include <iostream>
@@ -29,12 +30,16 @@ constexpr const char* INVALID_LBA = "100";
 
 class SSDTest : public ::testing::Test {
  protected:
-  SsdController* ssdInterface;
+  SsdController* ssdControllerWithTest;
 
-  void SetUp() override { ssdInterface = new SsdController(); }
+  void SetUp() override {
+    std::unique_ptr<SsdComponentFactory> testFactory =
+        std::make_unique<TestSsdComponentFactory>();
+    ssdControllerWithTest = new SsdController(std::move(testFactory));
+  }
 
   void TearDown() override {
-    delete ssdInterface;
+    delete ssdControllerWithTest;
     if (fs::exists(OUTPUT_FILE_NAME)) fs::remove(OUTPUT_FILE_NAME);
     if (fs::exists(NAND_FILE_NAME)) fs::remove(NAND_FILE_NAME);
     if (fs::exists(COMMAND_BUFFER_FOLDER_NAME))
@@ -44,138 +49,138 @@ class SSDTest : public ::testing::Test {
 
 TEST_F(SSDTest, ErasePassLBA0To1) {
   for (int i = 0; i < 100; i++) {
-    ssdInterface->Write(std::to_string(i), VALID_VALUE_1);
+    ssdControllerWithTest->Write(std::to_string(i), VALID_VALUE_1);
   }
-  ssdInterface->Erase(VALID_LBA_BEGIN, VALID_ERASE_SCOPE_1);
-  ssdInterface->Read(VALID_LBA_BEGIN);
-  EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(VALID_LBA_BEGIN, VALID_ERASE_SCOPE_1);
+  ssdControllerWithTest->Read(VALID_LBA_BEGIN);
+  EXPECT_EQ(ZERO_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, ErasePassLBA0To10) {
   for (int i = 0; i < 100; i++) {
-    ssdInterface->Write(std::to_string(i), VALID_VALUE_1);
+    ssdControllerWithTest->Write(std::to_string(i), VALID_VALUE_1);
   }
-  ssdInterface->Erase(VALID_LBA_BEGIN, VALID_ERASE_SCOPE_10);
+  ssdControllerWithTest->Erase(VALID_LBA_BEGIN, VALID_ERASE_SCOPE_10);
   for (int i = 0; i < 10; i++) {
-    ssdInterface->Read(std::to_string(i));
-    EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
+    ssdControllerWithTest->Read(std::to_string(i));
+    EXPECT_EQ(ZERO_PATTERN, ssdControllerWithTest->GetResult());
   }
 }
 
 TEST_F(SSDTest, EraseErrorLBA0To11) {
   for (int i = 0; i < 100; i++) {
-    ssdInterface->Write(std::to_string(i), VALID_VALUE_1);
+    ssdControllerWithTest->Write(std::to_string(i), VALID_VALUE_1);
   }
-  ssdInterface->Erase(VALID_LBA_BEGIN, INVALID_ERASE_SCOPE_11);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(VALID_LBA_BEGIN, INVALID_ERASE_SCOPE_11);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, EraseErrorLBA95To6) {
   for (int i = 0; i < 100; i++) {
-    ssdInterface->Write(std::to_string(i), VALID_VALUE_1);
+    ssdControllerWithTest->Write(std::to_string(i), VALID_VALUE_1);
   }
-  ssdInterface->Erase(VALID_LBA_95, VALID_ERASE_SCOPE_6);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(VALID_LBA_95, VALID_ERASE_SCOPE_6);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, EraseErrorInvalidLBA) {
   for (int i = 0; i < 100; i++) {
-    ssdInterface->Write(std::to_string(i), VALID_VALUE_1);
+    ssdControllerWithTest->Write(std::to_string(i), VALID_VALUE_1);
   }
-  ssdInterface->Erase(INVALID_LBA, VALID_ERASE_SCOPE_10);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(INVALID_LBA, VALID_ERASE_SCOPE_10);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Write_Pass_0) {
-  ssdInterface->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
-  EXPECT_NE(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
+  EXPECT_NE(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Write_Pass_1) {
-  ssdInterface->Write(VALID_LBA_END, VALID_VALUE_1);
-  EXPECT_NE(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Write(VALID_LBA_END, VALID_VALUE_1);
+  EXPECT_NE(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Read_Mapped_0) {
-  ssdInterface->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
-  ssdInterface->Read(VALID_LBA_BEGIN);
-  EXPECT_EQ(VALID_VALUE_1, ssdInterface->GetResult());
+  ssdControllerWithTest->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
+  ssdControllerWithTest->Read(VALID_LBA_BEGIN);
+  EXPECT_EQ(VALID_VALUE_1, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Read_Mapped_1) {
-  ssdInterface->Write(VALID_LBA_END, VALID_VALUE_1);
-  ssdInterface->Read(VALID_LBA_END);
-  EXPECT_EQ(VALID_VALUE_1, ssdInterface->GetResult());
+  ssdControllerWithTest->Write(VALID_LBA_END, VALID_VALUE_1);
+  ssdControllerWithTest->Read(VALID_LBA_END);
+  EXPECT_EQ(VALID_VALUE_1, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Read_Unmapped) {
-  ssdInterface->Read(VALID_LBA_BEGIN);
-  EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Read(VALID_LBA_BEGIN);
+  EXPECT_EQ(ZERO_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, CreateOutputFileIfNotExists) {
   ASSERT_FALSE(fs::exists(OUTPUT_FILE_NAME));
-  ssdInterface->Read(VALID_LBA_BEGIN);
+  ssdControllerWithTest->Read(VALID_LBA_BEGIN);
   ASSERT_TRUE(fs::exists(OUTPUT_FILE_NAME));
 }
 
 TEST_F(SSDTest, Write_Pass_After_Read) {
-  EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
-  ssdInterface->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
-  EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
+  EXPECT_EQ(ZERO_PATTERN, ssdControllerWithTest->GetResult());
+  ssdControllerWithTest->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
+  EXPECT_EQ(ZERO_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Write_Fail_OutOfRange) {
-  ssdInterface->Write(INVALID_LBA, VALID_VALUE_1);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Write(INVALID_LBA, VALID_VALUE_1);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Write_Fail_InvalidPattern_0) {
-  ssdInterface->Write(VALID_LBA_BEGIN, INVALID_VALUE_1);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Write(VALID_LBA_BEGIN, INVALID_VALUE_1);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Write_Fail_InvalidPattern_1) {
-  ssdInterface->ClearCommandBuffer();
-  ssdInterface->Write(VALID_LBA_BEGIN, INVALID_VALUE_2);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->ClearCommandBuffer();
+  ssdControllerWithTest->Write(VALID_LBA_BEGIN, INVALID_VALUE_2);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Read_Unmapped_After_Write_1) {
-  ssdInterface->ClearCommandBuffer();
-  ssdInterface->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
-  ssdInterface->Read(VALID_LBA_END);
-  EXPECT_EQ(ZERO_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->ClearCommandBuffer();
+  ssdControllerWithTest->Write(VALID_LBA_BEGIN, VALID_VALUE_1);
+  ssdControllerWithTest->Read(VALID_LBA_END);
+  EXPECT_EQ(ZERO_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Read_Fail_OutOfRange) {
-  ssdInterface->Read(INVALID_LBA);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Read(INVALID_LBA);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Erase_Pass_MinusSize) {
   std::string minusSize = "-5";
-  ssdInterface->Erase(VALID_LBA_END, minusSize);
-  EXPECT_NE(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(VALID_LBA_END, minusSize);
+  EXPECT_NE(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Erase_Fail_MinusLba) {
   std::string minusLba = "-3";
-  ssdInterface->Erase(minusLba, VALID_ERASE_SCOPE_1);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(minusLba, VALID_ERASE_SCOPE_1);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Erase_Fail_MinusSize) {
   std::string minusSize = "-5";
-  ssdInterface->Erase(VALID_LBA_BEGIN, minusSize);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(VALID_LBA_BEGIN, minusSize);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 TEST_F(SSDTest, Erase_Fail_MinusLbaAndSize) {
   std::string minusLba = "-3";
   std::string minusSize = "-5";
-  ssdInterface->Erase(minusLba, minusSize);
-  EXPECT_EQ(ERROR_PATTERN, ssdInterface->GetResult());
+  ssdControllerWithTest->Erase(minusLba, minusSize);
+  EXPECT_EQ(ERROR_PATTERN, ssdControllerWithTest->GetResult());
 }
 
 int main() { 


### PR DESCRIPTION
SsdController 에서 사용중인 NandStorage, Validator, Recoder 객체에 대해 Factory pattern 적용. 현재는 real 과 test 모두 동일하게 생성하고 있지만 추후 목적에 맞게 각 객체를 다르게 생성할 수 있음.