### PR TITLE
[REFACTOR] EraseCommand 로직 분리 및 유효성 처리 구조 개선

### DIFF
--- a/TestShell/EraseCommand.h
+++ b/TestShell/EraseCommand.h
@@ -1,22 +1,28 @@
-#pragma once
-
+﻿#pragma once
 #include "ICommand.h"
 #include <string>
 #include <vector>
 
 class EraseCommand : public ICommand {
 public:
-    EraseCommand() = default;
-
     const std::string& getCommandString() override;
-    bool isMatch(const string& command) override;
     const std::string& getUsage() override;
+    bool isMatch(const std::string& command) override;
     bool isValidArguments(const std::string& cmd, std::vector<std::string>& args) override;
     bool Execute(const std::string& cmd, std::vector<std::string>& args) override;
 
 protected:
     virtual int callSystem(const std::string& cmd);
     virtual std::string readOutput();
+
 private:
     const std::string cmd = "erase";
+
+    struct EraseCall {
+        int lba;
+        int size;
+    };
+
+    std::vector<EraseCall> groupAndChunk(const std::vector<EraseCall>& calls);
+    void performEraseCalls(const std::vector<EraseCall>& calls);
 };


### PR DESCRIPTION
- 연속 LBA 그룹핑 및 10칸 단위 분할 로직을 groupAndChunk 함수로 분리하여 중복 제거
- system call 분리 및 메시지 출력을 performEraseCalls 함수로 모듈화
- 전체 LBA에 대해 유효/무효를 구분하여 처리 로직 일원화